### PR TITLE
chore: integrate updated sorting logic

### DIFF
--- a/src/JokeraceEligibility.sol
+++ b/src/JokeraceEligibility.sol
@@ -155,13 +155,13 @@ contract JokeraceEligibility is HatsEligibilityModule {
     uint256 k = topK; // save SLOADs
     uint256 numEligibleWearers = numProposals > k ? k : numProposals;
 
-
     for (uint256 i; i < numEligibleWearers;) {
       uint256 forVotesOfCurrentRank = currentContest.sortedRanks(currentContest.getRankIndex(i));
       uint256 numProposalsWithRankIVotes = currentContest.getNumProposalsWithThisManyForVotes(forVotesOfCurrentRank);
-      if (numProposalsWithRankIVotes > 1) revert JokeraceEligibility_NoTies(); // revert if a rank that a hat is to go to is tied
+      if (numProposalsWithRankIVotes > 1) revert JokeraceEligibility_NoTies(); // revert if a rank is tied
 
-      address candidate = getCandidate(currentContest, currentContest.getOnlyProposalIdWithThisManyForVotes(forVotesOfCurrentRank));
+      address candidate =
+        getCandidate(currentContest, currentContest.getOnlyProposalIdWithThisManyForVotes(forVotesOfCurrentRank));
       eligibleWearersPerContest[candidate][address(currentContest)] = true;
 
       // should not overflow based on < numEligibleWearers stopping condition

--- a/src/JokeraceEligibility.sol
+++ b/src/JokeraceEligibility.sol
@@ -7,7 +7,7 @@ import { IHatsEligibility } from "hats-protocol/Interfaces/IHatsEligibility.sol"
 import { IHats } from "hats-protocol/Interfaces/IHats.sol";
 import { HatsEligibilityModule, HatsModule } from "hats-module/HatsEligibilityModule.sol";
 import { GovernorCountingSimple } from "jokerace/governance/extensions/GovernorCountingSimple.sol";
-import { IGovernor } from "jokerace/governance/IGovernor.sol";
+import { Governor } from "jokerace/governance/Governor.sol";
 
 contract JokeraceEligibility is HatsEligibilityModule {
   /*//////////////////////////////////////////////////////////////
@@ -145,7 +145,7 @@ contract JokeraceEligibility is HatsEligibilityModule {
   function pullElectionResults() public {
     GovernorCountingSimple currentContest = GovernorCountingSimple(payable(underlyingContest));
 
-    if (currentContest.state() != IGovernor.ContestState.Completed) revert JokeraceEligibility_ContestNotCompleted();
+    if (currentContest.state() != Governor.ContestState.Completed) revert JokeraceEligibility_ContestNotCompleted();
     if (currentContest.downvotingAllowed() == 1) revert JokeraceEligibility_MustHaveDownvotingDisabled();
     if (currentContest.sortingEnabled() == 0) revert JokeraceEligibility_MustHaveSortingEnabled();
 
@@ -207,7 +207,7 @@ contract JokeraceEligibility is HatsEligibilityModule {
   /// @notice Check if setting a new election is allowed.
   function reelectionAllowed() public view returns (bool allowed) {
     allowed = block.timestamp >= termEnd
-      || GovernorCountingSimple(payable(underlyingContest)).state() == IGovernor.ContestState.Canceled;
+      || GovernorCountingSimple(payable(underlyingContest)).state() == Governor.ContestState.Canceled;
   }
 
   /*//////////////////////////////////////////////////////////////

--- a/src/JokeraceEligibility.sol
+++ b/src/JokeraceEligibility.sol
@@ -152,11 +152,9 @@ contract JokeraceEligibility is HatsEligibilityModule {
     uint256[] memory proposalIds = currentContest.getAllProposalIds();
     uint256 numDeletedProposals = currentContest.getAllDeletedProposalIds().length;
     uint256 numProposals = proposalIds.length - numDeletedProposals;
-    uint256 numEligibleWearers;
-
     uint256 k = topK; // save SLOADs
+    uint256 numEligibleWearers = numProposals > k ? k : numProposals;
 
-    numEligibleWearers = numProposals > k ? k : numProposals;
 
     for (uint256 i; i < numEligibleWearers;) {
       uint256 forVotesOfCurrentRank = currentContest.sortedRanks(currentContest.getRankIndex(i));

--- a/test/JokeraceEligibility.t.sol
+++ b/test/JokeraceEligibility.t.sol
@@ -10,9 +10,9 @@ import {
   deployModuleFactory,
   deployModuleInstance
 } from "lib/hats-module/src/utils/DeployFunctions.sol";
-import { GovernorSorting } from "jokerace/governance/extensions/GovernorSorting.sol";
+import { GovernorSorting } from "jokerace/governance/utils/GovernorSorting.sol";
+import { Governor } from "jokerace/governance/Governor.sol";
 import { Contest } from "jokerace/Contest.sol";
-import { IGovernor } from "jokerace/governance/IGovernor.sol";
 
 contract DeployImplementationTest is DeployImplementation, Test {
   // variables inherited from DeployImplementation script
@@ -204,32 +204,32 @@ contract Proposing1Scenario is TestSetup {
 
     // each candidate proposes and delegates to itself
     vm.prank(candidate1);
-    IGovernor.ProposalCore memory proposal1 = IGovernor.ProposalCore({
+    Governor.ProposalCore memory proposal1 = Governor.ProposalCore({
       author: candidate1,
       description: "candidate 1 proposal",
       exists: true,
-      targetMetadata: IGovernor.TargetMetadata({ targetAddress: candidate1 }),
-      safeMetadata: IGovernor.SafeMetadata({ signers: signers1, threshold: 1 })
+      targetMetadata: Governor.TargetMetadata({ targetAddress: candidate1 }),
+      safeMetadata: Governor.SafeMetadata({ signers: signers1, threshold: 1 })
     });
     contest.proposeWithoutProof(proposal1);
 
     vm.prank(candidate2);
-    IGovernor.ProposalCore memory proposal2 = IGovernor.ProposalCore({
+    Governor.ProposalCore memory proposal2 = Governor.ProposalCore({
       author: candidate2,
       description: "candidate 2 proposal",
       exists: true,
-      targetMetadata: IGovernor.TargetMetadata({ targetAddress: candidate2 }),
-      safeMetadata: IGovernor.SafeMetadata({ signers: signers2, threshold: 1 })
+      targetMetadata: Governor.TargetMetadata({ targetAddress: candidate2 }),
+      safeMetadata: Governor.SafeMetadata({ signers: signers2, threshold: 1 })
     });
     contest.proposeWithoutProof(proposal2);
 
     vm.prank(candidate3);
-    IGovernor.ProposalCore memory proposal3 = IGovernor.ProposalCore({
+    Governor.ProposalCore memory proposal3 = Governor.ProposalCore({
       author: candidate3,
       description: "candidate 3 proposal",
       exists: true,
-      targetMetadata: IGovernor.TargetMetadata({ targetAddress: candidate3 }),
-      safeMetadata: IGovernor.SafeMetadata({ signers: signers3, threshold: 1 })
+      targetMetadata: Governor.TargetMetadata({ targetAddress: candidate3 }),
+      safeMetadata: Governor.SafeMetadata({ signers: signers3, threshold: 1 })
     });
     contest.proposeWithoutProof(proposal3);
 
@@ -248,12 +248,12 @@ contract Proposing2Scenario is TestSetup {
 
     // only one proposal
     vm.prank(candidate1);
-    IGovernor.ProposalCore memory proposal1 = IGovernor.ProposalCore({
+    Governor.ProposalCore memory proposal1 = Governor.ProposalCore({
       author: candidate1,
       description: "candidate 1 proposal",
       exists: true,
-      targetMetadata: IGovernor.TargetMetadata({ targetAddress: candidate1 }),
-      safeMetadata: IGovernor.SafeMetadata({ signers: signers1, threshold: 1 })
+      targetMetadata: Governor.TargetMetadata({ targetAddress: candidate1 }),
+      safeMetadata: Governor.SafeMetadata({ signers: signers1, threshold: 1 })
     });
     contest.proposeWithoutProof(proposal1);
 


### PR DESCRIPTION
We recently refactored our `GovernorSorting.sol` logic in https://github.com/jk-labs-inc/jokerace/pull/974 to enable sorting at scale (and specifically the ability to have rewards for contests that have more than 100 submissions).

It's a pretty significant refactor to what we had previously so wanted to let y'all know, but thought I'd go ahead and put up a PR adjusting the eligibility module to the changes to help with the transition too.

The one way in which this change requires a change in the logic of the module is that with the new structure, there is no easy way to see how many proposals there are for ranks 1-k, so it will require augmentation in how y'all want to deal with ties. I have added a suggestion here but up to y'all!