### PR TITLE
Integrate updated Jokerace

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,6 +7,3 @@
 [submodule "lib/hats-module"]
 	path = lib/hats-module
 	url = https://github.com/Hats-Protocol/hats-module
-[submodule "lib/jokerace"]
-	path = lib/jokerace
-	url = https://github.com/jk-labs-inc/jokerace

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,9 +4,6 @@
 [submodule "lib/hats-protocol"]
 	path = lib/hats-protocol
 	url = https://github.com/Hats-Protocol/hats-protocol
-[submodule "lib/jokerace"]
-	path = lib/jokerace
-	url = https://github.com/jk-labs-inc/jokerace
 [submodule "lib/hats-module"]
 	path = lib/hats-module
 	url = https://github.com/Hats-Protocol/hats-module

--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "lib/hats-module"]
 	path = lib/hats-module
 	url = https://github.com/Hats-Protocol/hats-module
+[submodule "lib/jokerace"]
+	path = lib/jokerace
+	url = https://github.com/jk-labs-inc/jokerace

--- a/script/JokeraceEligibility.s.sol
+++ b/script/JokeraceEligibility.s.sol
@@ -12,7 +12,7 @@ contract DeployImplementation is Script {
   bytes32 public SALT = keccak256("lets add some salt to this meal");
 
   // default values
-  string public version = "0.3.0"; // increment with each deploy
+  string public version = "0.4.0"; // increment with each deploy
   bool private verbose = true;
 
   /// @notice Override default values, if desired

--- a/src/JokeraceEligibility.sol
+++ b/src/JokeraceEligibility.sol
@@ -162,16 +162,16 @@ contract JokeraceEligibility is HatsEligibilityModule {
     while (!processed) {
       try currentContest.getRankIndex(currentRank) returns (uint256 rankIndex) {
         uint256 forVotesOfCurrentRank = currentContest.sortedRanks(rankIndex);
-        uint256[] memory proposalsOfCurrentRank = currentContest.forVotesToProposalIds(forVotesOfCurrentRank);
-        uint256 numProposalsWithCurrentRank = proposalsOfCurrentRank.length;
-        winningProposalsCount += numProposalsWithCurrentRank;
+        uint256[] memory proposalsOfCurrentRank = currentContest.getProposalsWithThisManyForVotes(forVotesOfCurrentRank);
+        uint256 numProposalsOfCurrentRank = proposalsOfCurrentRank.length;
+        winningProposalsCount += numProposalsOfCurrentRank;
 
         if (winningProposalsCount > k) {
           termEnd = block.timestamp;
           revert JokeraceEligibility_NoTies();
         }
 
-        for (uint256 i; i < numProposalsWithCurrentRank;) {
+        for (uint256 i; i < numProposalsOfCurrentRank;) {
           address candidate = getCandidate(currentContest, proposalsOfCurrentRank[i]);
           eligibleWearersPerContest[candidate][address(currentContest)] = true;
 
@@ -179,11 +179,15 @@ contract JokeraceEligibility is HatsEligibilityModule {
             ++i;
           }
         }
+
+        if (winningProposalsCount == k) {
+          processed = true;
+        }
+
+        currentRank += 1;
       } catch {
         processed = true;
       }
-
-      currentRank += 1;
     }
   }
 

--- a/src/JokeraceEligibility.sol
+++ b/src/JokeraceEligibility.sol
@@ -96,6 +96,15 @@ contract JokeraceEligibility is HatsEligibilityModule {
   function _setUp(bytes calldata _initData) internal override {
     (address payable _underlyingContest, uint256 _termEnd, uint256 _topK) =
       abi.decode(_initData, (address, uint256, uint256));
+
+    GovernorCountingSimple contest = GovernorCountingSimple(payable(_underlyingContest));
+    if (contest.downvotingAllowed() == 1) {
+      revert JokeraceEligibility_MustHaveDownvotingDisabled();
+    }
+    if (contest.sortingEnabled() == 0) {
+      revert JokeraceEligibility_MustHaveSortingEnabled();
+    }
+
     // initialize the mutable state vars
     underlyingContest = _underlyingContest;
     termEnd = _termEnd;
@@ -148,12 +157,6 @@ contract JokeraceEligibility is HatsEligibilityModule {
     if (currentContest.state() != Governor.ContestState.Completed) {
       revert JokeraceEligibility_ContestNotCompleted();
     }
-    if (currentContest.downvotingAllowed() == 1) {
-      revert JokeraceEligibility_MustHaveDownvotingDisabled();
-    }
-    if (currentContest.sortingEnabled() == 0) {
-      revert JokeraceEligibility_MustHaveSortingEnabled();
-    }
 
     uint256 k = topK;
     uint256 winningProposalsCount = 0;
@@ -199,6 +202,14 @@ contract JokeraceEligibility is HatsEligibilityModule {
   function reelection(address newUnderlyingContest, uint256 newTermEnd, uint256 newTopK) public {
     if (!reelectionAllowed()) {
       revert JokeraceEligibility_TermNotCompleted();
+    }
+
+    GovernorCountingSimple newContest = GovernorCountingSimple(payable(newUnderlyingContest));
+    if (newContest.downvotingAllowed() == 1) {
+      revert JokeraceEligibility_MustHaveDownvotingDisabled();
+    }
+    if (newContest.sortingEnabled() == 0) {
+      revert JokeraceEligibility_MustHaveSortingEnabled();
     }
 
     uint256 admin = ADMIN_HAT();

--- a/src/JokeraceEligibility.sol
+++ b/src/JokeraceEligibility.sol
@@ -94,7 +94,7 @@ contract JokeraceEligibility is HatsEligibilityModule {
     (address payable _underlyingContest, uint256 _termEnd, uint256 _topK) =
       abi.decode(_initData, (address, uint256, uint256));
 
-    checkContestSupportsSorting(GovernorCountingSimple(_underlyingContest));
+    _checkContestSupportsSorting(GovernorCountingSimple(_underlyingContest));
 
     // initialize the mutable state vars
     underlyingContest = _underlyingContest;
@@ -166,7 +166,7 @@ contract JokeraceEligibility is HatsEligibilityModule {
 
         // get the authors of the proposals and update their eligibility
         for (uint256 proposalIndex; proposalIndex < numProposalsOfCurrentRank;) {
-          address candidate = getCandidate(currentContest, proposalsOfCurrentRank[proposalIndex]);
+          address candidate = _getCandidate(currentContest, proposalsOfCurrentRank[proposalIndex]);
           eligibleWearersPerContest[candidate][address(currentContest)] = true;
 
           unchecked {
@@ -200,7 +200,7 @@ contract JokeraceEligibility is HatsEligibilityModule {
       revert JokeraceEligibility_TermNotCompleted();
     }
 
-    checkContestSupportsSorting(GovernorCountingSimple(payable(newUnderlyingContest)));
+    _checkContestSupportsSorting(GovernorCountingSimple(payable(newUnderlyingContest)));
 
     uint256 admin = ADMIN_HAT();
     // if an admin hat is not set, then the Hats admins of hatId are granted the permission to set a reelection
@@ -235,11 +235,11 @@ contract JokeraceEligibility is HatsEligibilityModule {
                         INTERNAL FUNCTIONS
     //////////////////////////////////////////////////////////////*/
 
-  function getCandidate(GovernorCountingSimple contest, uint256 proposalId) internal view returns (address candidate) {
+  function _getCandidate(GovernorCountingSimple contest, uint256 proposalId) internal view returns (address candidate) {
     candidate = contest.getProposal(proposalId).author;
   }
 
-  function checkContestSupportsSorting(GovernorCountingSimple contest) internal view {
+  function _checkContestSupportsSorting(GovernorCountingSimple contest) internal view {
     if (contest.downvotingAllowed() == 1) {
       revert JokeraceEligibility_MustHaveDownvotingDisabled();
     }

--- a/test/JokeraceEligibility.t.sol
+++ b/test/JokeraceEligibility.t.sol
@@ -10,9 +10,9 @@ import {
   deployModuleFactory,
   deployModuleInstance
 } from "lib/hats-module/src/utils/DeployFunctions.sol";
-import { GovernorSorting } from "jokerace/governance/extensions/GovernorSorting.sol";
+//import { GovernorSorting } from "jokerace/governance/extensions/GovernorSorting.sol";
 import { Contest } from "jokerace/Contest.sol";
-import { IGovernor } from "jokerace/governance/IGovernor.sol";
+//import { IGovernor } from "jokerace/governance/IGovernor.sol";
 
 contract DeployImplementationTest is DeployImplementation, Test {
   // variables inherited from DeployImplementation script
@@ -21,488 +21,413 @@ contract DeployImplementationTest is DeployImplementation, Test {
 
   uint256 public fork;
   uint256 public BLOCK_NUMBER = 9_395_052; // the block number where hats module factory was deployed on Goerli;
-
-  IHats public constant HATS = IHats(0x3bc1A0Ad72417f2d411118085256fC53CBdDd137); // v1.hatsprotocol.eth
-  string public FACTORY_VERSION = "factory test version";
-  string public JOKERACE_ELIGIBILITY_VERSION = "test version";
-
-  function setUp() public virtual {
-    // create and activate a fork, at BLOCK_NUMBER
-    fork = vm.createSelectFork(vm.rpcUrl("goerli"), BLOCK_NUMBER);
-
-    // deploy via the script
-    DeployImplementation.prepare(JOKERACE_ELIGIBILITY_VERSION, false); // set last arg to true to log deployment
-    DeployImplementation.run();
-  }
-}
-
-contract TestSetup is DeployImplementationTest {
-  error JokeraceEligibility_ContestNotCompleted();
-  error JokeraceEligibility_TermNotCompleted();
-  error JokeraceEligibility_NoTies();
-  error JokeraceEligibility_NotAdmin();
-
-  HatsModuleFactory constant FACTORY = HatsModuleFactory(0x60f7bE2ffc5672934146713fAe20Df350F21d8E2);
-  JokeraceEligibility public instanceDefaultAdmin;
-  JokeraceEligibility public instanceHatAdmin;
-  bytes public otherImmutableArgs;
-  bytes public initData;
-
-  uint256 public tophat;
-  uint256 public winnersHat;
-  uint256 public optionalAdminHat;
-  address public eligibility = makeAddr("eligibility");
-  address public toggle = makeAddr("toggle");
-  address public dao = makeAddr("dao");
-
-  address public minter = makeAddr("minter");
-  address public optionalAdmin = makeAddr("optionalAdmin");
-  address public candidate1 = makeAddr("candidate1");
-  address public candidate2 = makeAddr("candidate2");
-  address public candidate3 = makeAddr("candidate3");
-  bytes32 leaf1;
-  bytes32 leaf2;
-  bytes32 leaf3;
-  bytes32[] proof1;
-  bytes32[] proof2;
-  bytes32[] proof3;
-  bytes32 votingMerkleRoot;
-  address[] signers1 = [candidate1];
-  address[] signers2 = [candidate2];
-  address[] signers3 = [candidate3];
-
-  Contest contest;
-  //GenericVotesTimestampToken token;
-  uint256[] args;
-  uint256 contestStart;
-  uint256 constant voteDelay = 3600;
-  uint256 constant votePeriod = 3600;
-  uint256 constant termPeriod = 86_400;
-
-  enum ContestState {
-    NotStarted,
-    Active,
-    Canceled,
-    Queued,
-    Completed
-  }
-
-  function deployInstance(uint256 _winnersHat, uint256 _adminHat, address _contest, uint256 _termEnd, uint256 _topK)
-    public
-    returns (JokeraceEligibility)
-  {
-    // encode the other immutable args as packed bytes
-    otherImmutableArgs = abi.encodePacked(_adminHat);
-    // encoded the initData as unpacked bytes
-    initData = abi.encode(_contest, _termEnd, _topK);
-    // deploy the instance
-    return JokeraceEligibility(
+    /*
+      IHats public constant HATS = IHats(0x3bc1A0Ad72417f2d411118085256fC53CBdDd137); // v1.hatsprotocol.eth
+      string public FACTORY_VERSION = "factory test version";
+      string public JOKERACE_ELIGIBILITY_VERSION = "test version";
+      function setUp() public virtual {
+      // create and activate a fork, at BLOCK_NUMBER
+      fork = vm.createSelectFork(vm.rpcUrl("goerli"), BLOCK_NUMBER);
+      // deploy via the script
+      DeployImplementation.prepare(JOKERACE_ELIGIBILITY_VERSION, false); // set last arg to true to log deployment
+      DeployImplementation.run();
+      }
+      }
+      contract TestSetup is DeployImplementationTest {
+      error JokeraceEligibility_ContestNotCompleted();
+      error JokeraceEligibility_TermNotCompleted();
+      error JokeraceEligibility_NoTies();
+      error JokeraceEligibility_NotAdmin();
+      HatsModuleFactory constant FACTORY = HatsModuleFactory(0x60f7bE2ffc5672934146713fAe20Df350F21d8E2);
+      JokeraceEligibility public instanceDefaultAdmin;
+      JokeraceEligibility public instanceHatAdmin;
+      bytes public otherImmutableArgs;
+      bytes public initData;
+      uint256 public tophat;
+      uint256 public winnersHat;
+      uint256 public optionalAdminHat;
+      address public eligibility = makeAddr("eligibility");
+      address public toggle = makeAddr("toggle");
+      address public dao = makeAddr("dao");
+      address public minter = makeAddr("minter");
+      address public optionalAdmin = makeAddr("optionalAdmin");
+      address public candidate1 = makeAddr("candidate1");
+      address public candidate2 = makeAddr("candidate2");
+      address public candidate3 = makeAddr("candidate3");
+      bytes32 leaf1;
+      bytes32 leaf2;
+      bytes32 leaf3;
+      bytes32[] proof1;
+      bytes32[] proof2;
+      bytes32[] proof3;
+      bytes32 votingMerkleRoot;
+      address[] signers1 = [candidate1];
+      address[] signers2 = [candidate2];
+      address[] signers3 = [candidate3];
+      Contest contest;
+      //GenericVotesTimestampToken token;
+      uint256[] args;
+      uint256 contestStart;
+      uint256 constant voteDelay = 3600;
+      uint256 constant votePeriod = 3600;
+      uint256 constant termPeriod = 86_400;
+      enum ContestState {
+      NotStarted,
+      Active,
+      Canceled,
+      Queued,
+      Completed
+      }
+      function deployInstance(uint256 _winnersHat, uint256 _adminHat, address _contest, uint256 _termEnd, uint256 _topK)
+      public
+      returns (JokeraceEligibility)
+      {
+      // encode the other immutable args as packed bytes
+      otherImmutableArgs = abi.encodePacked(_adminHat);
+      // encoded the initData as unpacked bytes
+      initData = abi.encode(_contest, _termEnd, _topK);
+      // deploy the instance
+      return JokeraceEligibility(
       deployModuleInstance(FACTORY, address(implementation), _winnersHat, otherImmutableArgs, initData)
-    );
-  }
-
-  function _efficientHash(bytes32 a, bytes32 b) private pure returns (bytes32 value) {
-    /// @solidity memory-safe-assembly
-    assembly {
+      );
+      }
+      function _efficientHash(bytes32 a, bytes32 b) private pure returns (bytes32 value) {
+      /// @solidity memory-safe-assembly
+      assembly {
       mstore(0x00, a)
       mstore(0x20, b)
       value := keccak256(0x00, 0x40)
-    }
-  }
-
-  function _hashPair(bytes32 a, bytes32 b) private pure returns (bytes32) {
-    return a < b ? _efficientHash(a, b) : _efficientHash(b, a);
-  }
-
-  function setUp() public virtual override {
-    super.setUp();
-    contestStart = block.timestamp;
-
-    // set up a contest
-    leaf1 = keccak256(abi.encodePacked(candidate1, uint256(100)));
-    leaf2 = keccak256(abi.encodePacked(candidate2, uint256(100)));
-    leaf3 = keccak256(abi.encodePacked(candidate3, uint256(100)));
-
-    proof1 = [leaf2, leaf3];
-    proof2 = [leaf1, leaf3];
-    proof3 = [_hashPair(leaf1, leaf2)];
-    votingMerkleRoot = _hashPair(_hashPair(leaf1, leaf2), leaf3);
-
-    args.push(contestStart);
-    args.push(voteDelay);
-    args.push(votePeriod);
-    args.push(50);
-    args.push(50);
-    args.push(1);
-    contest = new Contest("test contest", "contest", bytes32(0), votingMerkleRoot, args);
-
-    // set up hats
-    tophat = HATS.mintTopHat(dao, "tophat", "dao.eth/tophat");
-    vm.startPrank(dao);
-    winnersHat = HATS.createHat(tophat, "winnersHat", 50, eligibility, toggle, true, "dao.eth/winnersHat");
-    optionalAdminHat =
+      }
+      }
+      function _hashPair(bytes32 a, bytes32 b) private pure returns (bytes32) {
+      return a < b ? _efficientHash(a, b) : _efficientHash(b, a);
+      }
+      function setUp() public virtual override {
+      super.setUp();
+      contestStart = block.timestamp;
+      // set up a contest
+      leaf1 = keccak256(abi.encodePacked(candidate1, uint256(100)));
+      leaf2 = keccak256(abi.encodePacked(candidate2, uint256(100)));
+      leaf3 = keccak256(abi.encodePacked(candidate3, uint256(100)));
+      proof1 = [leaf2, leaf3];
+      proof2 = [leaf1, leaf3];
+      proof3 = [_hashPair(leaf1, leaf2)];
+      votingMerkleRoot = _hashPair(_hashPair(leaf1, leaf2), leaf3);
+      args.push(contestStart);
+      args.push(voteDelay);
+      args.push(votePeriod);
+      args.push(50);
+      args.push(50);
+      args.push(1);
+      contest = new Contest("test contest", "contest", bytes32(0), votingMerkleRoot, args);
+      // set up hats
+      tophat = HATS.mintTopHat(dao, "tophat", "dao.eth/tophat");
+      vm.startPrank(dao);
+      winnersHat = HATS.createHat(tophat, "winnersHat", 50, eligibility, toggle, true, "dao.eth/winnersHat");
+      optionalAdminHat =
       HATS.createHat(tophat, "optionalAdminHat", 50, eligibility, toggle, true, "dao.eth/optionalAdminHat");
-    HATS.mintHat(optionalAdminHat, optionalAdmin);
-    vm.stopPrank();
-
-    // deploy the eligibility instance with a default admin
-    instanceDefaultAdmin =
+      HATS.mintHat(optionalAdminHat, optionalAdmin);
+      vm.stopPrank();
+      // deploy the eligibility instance with a default admin
+      instanceDefaultAdmin =
       deployInstance(winnersHat, uint256(0), address(contest), contestStart + voteDelay + votePeriod + termPeriod, 2);
-
-    // deploy the eligibility instance with a specific hat admin. This instance is used only to check correct admin
-    // rights
-    instanceHatAdmin = deployInstance(
+      // deploy the eligibility instance with a specific hat admin. This instance is used only to check correct admin
+      // rights
+      instanceHatAdmin = deployInstance(
       winnersHat, optionalAdminHat, address(contest), contestStart + voteDelay + votePeriod + termPeriod, 2
-    );
-
-    // update winners hat eligibilty to instance
-    vm.prank(dao);
-    HATS.changeHatEligibility(winnersHat, address(instanceDefaultAdmin));
-  }
-}
-
-contract TestDeployment is TestSetup {
-  function test_deployImplementation() public {
-    assertEq(implementation.version_(), JOKERACE_ELIGIBILITY_VERSION, "implementation version");
-  }
-
-  function test_instanceDefaultAdmin() public {
-    assertEq(instanceDefaultAdmin.ADMIN_HAT(), uint256(0));
-  }
-
-  function test_instanceAdminHat() public {
-    assertEq(instanceHatAdmin.ADMIN_HAT(), optionalAdminHat);
-  }
-
-  function test_instanceContest() public {
-    assertEq(address(instanceDefaultAdmin.underlyingContest()), address(contest));
-  }
-
-  function test_instanceTermEnd() public {
-    assertEq(instanceDefaultAdmin.termEnd(), contest.contestDeadline() + 86_400);
-  }
-
-  function test_instanceTopK() public {
-    assertEq(instanceDefaultAdmin.topK(), 2);
-  }
-
-  function test_hatEligibility() public {
-    assertEq(
+      );
+      // update winners hat eligibilty to instance
+      vm.prank(dao);
+      HATS.changeHatEligibility(winnersHat, address(instanceDefaultAdmin));
+      }
+      }
+      contract TestDeployment is TestSetup {
+      function test_deployImplementation() public {
+      assertEq(implementation.version_(), JOKERACE_ELIGIBILITY_VERSION, "implementation version");
+      }
+      function test_instanceDefaultAdmin() public {
+      assertEq(instanceDefaultAdmin.ADMIN_HAT(), uint256(0));
+      }
+      function test_instanceAdminHat() public {
+      assertEq(instanceHatAdmin.ADMIN_HAT(), optionalAdminHat);
+      }
+      function test_instanceContest() public {
+      assertEq(address(instanceDefaultAdmin.underlyingContest()), address(contest));
+      }
+      function test_instanceTermEnd() public {
+      assertEq(instanceDefaultAdmin.termEnd(), contest.contestDeadline() + 86_400);
+      }
+      function test_instanceTopK() public {
+      assertEq(instanceDefaultAdmin.topK(), 2);
+      }
+      function test_hatEligibility() public {
+      assertEq(
       HATS.getHatEligibilityModule(winnersHat), address(instanceDefaultAdmin), "eligibility module of winners hat"
-    );
-  }
-}
-
-// Three candidates propose
-contract Proposing1Scenario is TestSetup {
-  uint256[] proposalIds;
-
-  function setUp() public virtual override {
-    super.setUp();
-    // set time to  proposing period
-    vm.warp(contestStart + voteDelay - 1);
-
-    // each candidate proposes and delegates to itself
-    vm.prank(candidate1);
-    IGovernor.ProposalCore memory proposal1 = IGovernor.ProposalCore({
+      );
+      }
+      }
+      // Three candidates propose
+      contract Proposing1Scenario is TestSetup {
+      uint256[] proposalIds;
+      function setUp() public virtual override {
+      super.setUp();
+      // set time to  proposing period
+      vm.warp(contestStart + voteDelay - 1);
+      // each candidate proposes and delegates to itself
+      vm.prank(candidate1);
+      IGovernor.ProposalCore memory proposal1 = IGovernor.ProposalCore({
       author: candidate1,
       description: "candidate 1 proposal",
       exists: true,
       targetMetadata: IGovernor.TargetMetadata({ targetAddress: candidate1 }),
       safeMetadata: IGovernor.SafeMetadata({ signers: signers1, threshold: 1 })
-    });
-    contest.proposeWithoutProof(proposal1);
-
-    vm.prank(candidate2);
-    IGovernor.ProposalCore memory proposal2 = IGovernor.ProposalCore({
+      });
+      contest.proposeWithoutProof(proposal1);
+      vm.prank(candidate2);
+      IGovernor.ProposalCore memory proposal2 = IGovernor.ProposalCore({
       author: candidate2,
       description: "candidate 2 proposal",
       exists: true,
       targetMetadata: IGovernor.TargetMetadata({ targetAddress: candidate2 }),
       safeMetadata: IGovernor.SafeMetadata({ signers: signers2, threshold: 1 })
-    });
-    contest.proposeWithoutProof(proposal2);
-
-    vm.prank(candidate3);
-    IGovernor.ProposalCore memory proposal3 = IGovernor.ProposalCore({
+      });
+      contest.proposeWithoutProof(proposal2);
+      vm.prank(candidate3);
+      IGovernor.ProposalCore memory proposal3 = IGovernor.ProposalCore({
       author: candidate3,
       description: "candidate 3 proposal",
       exists: true,
       targetMetadata: IGovernor.TargetMetadata({ targetAddress: candidate3 }),
       safeMetadata: IGovernor.SafeMetadata({ signers: signers3, threshold: 1 })
-    });
-    contest.proposeWithoutProof(proposal3);
-
-    proposalIds = contest.getAllProposalIds();
-  }
-}
-
-// Only one candidate proposes
-contract Proposing2Scenario is TestSetup {
-  uint256[] proposalIds;
-
-  function setUp() public virtual override {
-    super.setUp();
-    // set time to  proposing period
-    vm.warp(contestStart + voteDelay - 1);
-
-    // only one proposal
-    vm.prank(candidate1);
-    IGovernor.ProposalCore memory proposal1 = IGovernor.ProposalCore({
+      });
+      contest.proposeWithoutProof(proposal3);
+      proposalIds = contest.getAllProposalIds();
+      }
+      }
+      // Only one candidate proposes
+      contract Proposing2Scenario is TestSetup {
+      uint256[] proposalIds;
+      function setUp() public virtual override {
+      super.setUp();
+      // set time to  proposing period
+      vm.warp(contestStart + voteDelay - 1);
+      // only one proposal
+      vm.prank(candidate1);
+      IGovernor.ProposalCore memory proposal1 = IGovernor.ProposalCore({
       author: candidate1,
       description: "candidate 1 proposal",
       exists: true,
       targetMetadata: IGovernor.TargetMetadata({ targetAddress: candidate1 }),
       safeMetadata: IGovernor.SafeMetadata({ signers: signers1, threshold: 1 })
-    });
-    contest.proposeWithoutProof(proposal1);
-
-    proposalIds = contest.getAllProposalIds();
-  }
-}
-
-contract TestProposing1Scenario is Proposing1Scenario {
-  function setUp() public virtual override {
-    super.setUp();
-  }
-
-  function test_contestState() public {
-    assertEq(uint256(contest.state()), uint256(ContestState.Queued), "contest proposing state");
-  }
-
-  function test_proposals() public {
-    assertEq(proposalIds.length, 3, "number of proposals");
-  }
-
-  function test_pullContestResults_reverts() public {
-    vm.expectRevert(JokeraceEligibility_ContestNotCompleted.selector);
-    instanceDefaultAdmin.pullElectionResults();
-  }
-
-  function test_setReelection_reverts() public {
-    vm.expectRevert(JokeraceEligibility_TermNotCompleted.selector);
-    instanceDefaultAdmin.reelection(address(contest), contestStart + voteDelay + votePeriod + termPeriod, 2);
-  }
-}
-
-// Candidates scoring: candidate 1 > candidate 2 > candidate 3
-contract Voting1Proposing1Scenario is Proposing1Scenario {
-  function setUp() public virtual override {
-    super.setUp();
-
-    // set time to voting period
-    vm.warp(contestStart + voteDelay + 1);
-
-    // candidates vote
-    vm.prank(candidate1);
-    contest.castVote(proposalIds[0], 0, 100, 100, proof1);
-
-    vm.prank(candidate2);
-    contest.castVote(proposalIds[1], 0, 100, 50, proof2);
-
-    vm.prank(candidate3);
-    contest.castVote(proposalIds[2], 0, 100, 100, proof3);
-  }
-}
-
-// Candidates scoring (tie between second and third place): candidate 1 > candidate 2 = candidate 3
-contract Voting2Proposing1Scenario is Proposing1Scenario {
-  function setUp() public virtual override {
-    super.setUp();
-
-    // set time to voting period
-    vm.warp(contestStart + voteDelay + 1);
-
-    // candidates vote
-    vm.prank(candidate1);
-    contest.castVote(proposalIds[0], 0, 100, 100, proof1);
-
-    vm.prank(candidate2);
-    contest.castVote(proposalIds[1], 0, 100, 100, proof2);
-
-    vm.prank(candidate3);
-    contest.castVote(proposalIds[2], 0, 100, 100, proof3);
-  }
-}
-
-contract TestVoting1Proposing1Scenario is Voting1Proposing1Scenario {
-  function test_candidateVotes() public {
-    (uint256 forVotes1, uint256 againstVotes1) = contest.proposalVotes(proposalIds[0]);
-    assertEq(int256(forVotes1) - int256(againstVotes1), 100, "candidate 1 votes");
-
-    (uint256 forVotes2, uint256 againstVotes2) = contest.proposalVotes(proposalIds[1]);
-    assertEq(int256(forVotes2) - int256(againstVotes2), 50, "candidate 2 votes");
-
-    (uint256 forVotes3, uint256 againstVotes3) = contest.proposalVotes(proposalIds[2]);
-    assertEq(int256(forVotes3) - int256(againstVotes3), 100, "candidate 3 votes");
-  }
-
-  function test_pullContestResults_reverts() public {
-    vm.expectRevert(JokeraceEligibility_ContestNotCompleted.selector);
-    instanceDefaultAdmin.pullElectionResults();
-  }
-
-  function test_setReelection_reverts() public {
-    vm.expectRevert(JokeraceEligibility_TermNotCompleted.selector);
-    instanceDefaultAdmin.reelection(address(contest), contestStart + voteDelay + votePeriod + termPeriod, 2);
-  }
-}
-
-// Contest completed with candidates 1 & 2 as winners
-contract ContestCompletedVoting1Proposing1Scenario is Voting1Proposing1Scenario {
-  function setUp() public virtual override {
-    super.setUp();
-    // set time to contest completion
-    vm.warp(contestStart + voteDelay + votePeriod + 1);
-    instanceDefaultAdmin.pullElectionResults();
-  }
-}
-
-// Contest completed with a tie (should not accept ties)
-contract ContestCompletedVoting2Proposing1Scenario is Voting2Proposing1Scenario {
-  function setUp() public virtual override {
-    super.setUp();
-    // set time to contest completion
-    vm.warp(contestStart + voteDelay + votePeriod + 1);
-  }
-}
-
-// Contest completed with only one candidate, which is less than topK (2)
-contract ContestCompletedProposing2Scenario is Proposing2Scenario {
-  function setUp() public virtual override {
-    super.setUp();
-    // set time to contest completion
-    vm.warp(contestStart + voteDelay + votePeriod + 1);
-    instanceDefaultAdmin.pullElectionResults();
-  }
-}
-
-contract TestContestCompletedProposing2Scenario is ContestCompletedProposing2Scenario {
-  function test_eligibilityInstance() public {
-    (bool eligible1,) = instanceDefaultAdmin.getWearerStatus(candidate1, winnersHat);
-    assertEq(eligible1, true, "candidate 1 eligibility");
-    (bool eligible2,) = instanceDefaultAdmin.getWearerStatus(candidate2, winnersHat);
-    assertEq(eligible2, false, "candidate 2 eligibility");
-    (bool eligible3,) = instanceDefaultAdmin.getWearerStatus(candidate3, winnersHat);
-    assertEq(eligible3, false, "candidate 3 eligibility");
-  }
-
-  function test_eligibilityHats() public {
-    assertEq(HATS.isEligible(candidate1, winnersHat), true, "candidate 1 eligibility");
-    assertEq(HATS.isEligible(candidate2, winnersHat), false, "candidate 2 eligibility");
-    assertEq(HATS.isEligible(candidate3, winnersHat), false, "candidate 3 eligibility");
-  }
-}
-
-contract TestContestCompletedVoting2Proposing1Scenario is ContestCompletedVoting2Proposing1Scenario {
-  function test_pullResults_reverts() public {
-    vm.expectRevert(JokeraceEligibility_NoTies.selector);
-    instanceDefaultAdmin.pullElectionResults();
-  }
-}
-
-contract TestContestCompletedVoting1Proposing1Scenario is ContestCompletedVoting1Proposing1Scenario {
-  function test_eligibilityInstance() public {
-    (bool eligible1,) = instanceDefaultAdmin.getWearerStatus(candidate1, winnersHat);
-    assertEq(eligible1, true, "candidate 1 eligibility");
-    (bool eligible2,) = instanceDefaultAdmin.getWearerStatus(candidate2, winnersHat);
-    assertEq(eligible2, false, "candidate 2 eligibility");
-    (bool eligible3,) = instanceDefaultAdmin.getWearerStatus(candidate3, winnersHat);
-    assertEq(eligible3, true, "candidate 3 eligibility");
-  }
-
-  function test_eligibilityHats() public {
-    assertEq(HATS.isEligible(candidate1, winnersHat), true, "candidate 1 eligibility");
-    assertEq(HATS.isEligible(candidate2, winnersHat), false, "candidate 2 eligibility");
-    assertEq(HATS.isEligible(candidate3, winnersHat), true, "candidate 3 eligibility");
-  }
-
-  function test_setReelection_reverts() public {
-    vm.expectRevert(JokeraceEligibility_TermNotCompleted.selector);
-    instanceDefaultAdmin.reelection(address(contest), contestStart + voteDelay + votePeriod + termPeriod, 2);
-  }
-}
-
-// Current term ended, ready for reelection
-
-contract TermEndedVoting1Proposing1Scenario is ContestCompletedVoting1Proposing1Scenario {
-  function setUp() public virtual override {
-    super.setUp();
-    // set time to contest completion
-    vm.warp(contestStart + voteDelay + votePeriod + termPeriod + 1);
-  }
-}
-
-contract TestTermEndedVoting1Proposing1Scenario is TermEndedVoting1Proposing1Scenario {
-  function test_setReelectionNotAdmin_reverts() public {
-    vm.startPrank(candidate1);
-    vm.expectRevert(JokeraceEligibility_NotAdmin.selector);
-    instanceDefaultAdmin.reelection(address(contest), contestStart + voteDelay + votePeriod + termPeriod, 2);
-    vm.stopPrank();
-  }
-
-  function test_eligibilityInstance() public {
-    (bool eligible1,) = instanceDefaultAdmin.getWearerStatus(candidate1, winnersHat);
-    assertEq(eligible1, false, "candidate 1 eligibility");
-    (bool eligible2,) = instanceDefaultAdmin.getWearerStatus(candidate2, winnersHat);
-    assertEq(eligible2, false, "candidate 2 eligibility");
-    (bool eligible3,) = instanceDefaultAdmin.getWearerStatus(candidate3, winnersHat);
-    assertEq(eligible3, false, "candidate 3 eligibility");
-  }
-
-  function test_eligibilityHats() public {
-    assertEq(HATS.isEligible(candidate1, winnersHat), false, "candidate 1 eligibility");
-    assertEq(HATS.isEligible(candidate2, winnersHat), false, "candidate 2 eligibility");
-    assertEq(HATS.isEligible(candidate3, winnersHat), false, "candidate 3 eligibility");
-  }
-}
-
-contract TestReelectionVoting1Proposing1Scenario is TermEndedVoting1Proposing1Scenario {
-  function setUp() public virtual override {
-    super.setUp();
-
-    // deploy a new contest
-    contestStart = block.timestamp;
-    args.push(contestStart);
-    args.push(voteDelay);
-    args.push(votePeriod);
-    args.push(contestStart);
-    args.push(0);
-    args.push(50);
-    args.push(50);
-    args.push(1);
-    args.push(1);
-    contest = new Contest("test contest reelection", "contest reelection", bytes32(0), votingMerkleRoot, args);
-  }
-
-  function test_reelection() public {
-    vm.prank(dao);
-    address newContest = makeAddr("newContest");
-    uint256 newTermEnd = block.timestamp + voteDelay + votePeriod;
-    uint256 newTopK = 5;
-    instanceDefaultAdmin.reelection(newContest, newTermEnd, newTopK);
-    assertEq(address(instanceDefaultAdmin.underlyingContest()), newContest);
-    assertEq(instanceDefaultAdmin.topK(), newTopK);
-    assertEq(instanceDefaultAdmin.termEnd(), newTermEnd);
-  }
-}
-
-contract TestReelectionHatAdmin is TestSetup {
-  function setUp() public virtual override {
-    super.setUp();
-    // set time to contest completion
-    vm.warp(contestStart + voteDelay + votePeriod + termPeriod + 1);
-  }
-
-  function test_reelectionByTopHat_reverts() public {
-    vm.startPrank(dao);
-    vm.expectRevert(JokeraceEligibility_NotAdmin.selector);
-    instanceHatAdmin.reelection(address(contest), contestStart + voteDelay + votePeriod + termPeriod, 2);
-    vm.stopPrank();
-  }
-
-  function test_reelectionDefaultAdmin() public {
-    vm.prank(optionalAdmin);
-    instanceHatAdmin.reelection(address(contest), contestStart + voteDelay + votePeriod + termPeriod, 2);
-  }
+      });
+      contest.proposeWithoutProof(proposal1);
+      proposalIds = contest.getAllProposalIds();
+      }
+      }
+      contract TestProposing1Scenario is Proposing1Scenario {
+      function setUp() public virtual override {
+      super.setUp();
+      }
+      function test_contestState() public {
+      assertEq(uint256(contest.state()), uint256(ContestState.Queued), "contest proposing state");
+      }
+      function test_proposals() public {
+      assertEq(proposalIds.length, 3, "number of proposals");
+      }
+      function test_pullContestResults_reverts() public {
+      vm.expectRevert(JokeraceEligibility_ContestNotCompleted.selector);
+      instanceDefaultAdmin.pullElectionResults();
+      }
+      function test_setReelection_reverts() public {
+      vm.expectRevert(JokeraceEligibility_TermNotCompleted.selector);
+      instanceDefaultAdmin.reelection(address(contest), contestStart + voteDelay + votePeriod + termPeriod, 2);
+      }
+      }
+      // Candidates scoring: candidate 1 > candidate 2 > candidate 3
+      contract Voting1Proposing1Scenario is Proposing1Scenario {
+      function setUp() public virtual override {
+      super.setUp();
+      // set time to voting period
+      vm.warp(contestStart + voteDelay + 1);
+      // candidates vote
+      vm.prank(candidate1);
+      contest.castVote(proposalIds[0], 0, 100, 100, proof1);
+      vm.prank(candidate2);
+      contest.castVote(proposalIds[1], 0, 100, 50, proof2);
+      vm.prank(candidate3);
+      contest.castVote(proposalIds[2], 0, 100, 100, proof3);
+      }
+      }
+      // Candidates scoring (tie between second and third place): candidate 1 > candidate 2 = candidate 3
+      contract Voting2Proposing1Scenario is Proposing1Scenario {
+      function setUp() public virtual override {
+      super.setUp();
+      // set time to voting period
+      vm.warp(contestStart + voteDelay + 1);
+      // candidates vote
+      vm.prank(candidate1);
+      contest.castVote(proposalIds[0], 0, 100, 100, proof1);
+      vm.prank(candidate2);
+      contest.castVote(proposalIds[1], 0, 100, 100, proof2);
+      vm.prank(candidate3);
+      contest.castVote(proposalIds[2], 0, 100, 100, proof3);
+      }
+      }
+      contract TestVoting1Proposing1Scenario is Voting1Proposing1Scenario {
+      function test_candidateVotes() public {
+      (uint256 forVotes1, uint256 againstVotes1) = contest.proposalVotes(proposalIds[0]);
+      assertEq(int256(forVotes1) - int256(againstVotes1), 100, "candidate 1 votes");
+      (uint256 forVotes2, uint256 againstVotes2) = contest.proposalVotes(proposalIds[1]);
+      assertEq(int256(forVotes2) - int256(againstVotes2), 50, "candidate 2 votes");
+      (uint256 forVotes3, uint256 againstVotes3) = contest.proposalVotes(proposalIds[2]);
+      assertEq(int256(forVotes3) - int256(againstVotes3), 100, "candidate 3 votes");
+      }
+      function test_pullContestResults_reverts() public {
+      vm.expectRevert(JokeraceEligibility_ContestNotCompleted.selector);
+      instanceDefaultAdmin.pullElectionResults();
+      }
+      function test_setReelection_reverts() public {
+      vm.expectRevert(JokeraceEligibility_TermNotCompleted.selector);
+      instanceDefaultAdmin.reelection(address(contest), contestStart + voteDelay + votePeriod + termPeriod, 2);
+      }
+      }
+      // Contest completed with candidates 1 & 2 as winners
+      contract ContestCompletedVoting1Proposing1Scenario is Voting1Proposing1Scenario {
+      function setUp() public virtual override {
+      super.setUp();
+      // set time to contest completion
+      vm.warp(contestStart + voteDelay + votePeriod + 1);
+      instanceDefaultAdmin.pullElectionResults();
+      }
+      }
+      // Contest completed with a tie (should not accept ties)
+      contract ContestCompletedVoting2Proposing1Scenario is Voting2Proposing1Scenario {
+      function setUp() public virtual override {
+      super.setUp();
+      // set time to contest completion
+      vm.warp(contestStart + voteDelay + votePeriod + 1);
+      }
+      }
+      // Contest completed with only one candidate, which is less than topK (2)
+      contract ContestCompletedProposing2Scenario is Proposing2Scenario {
+      function setUp() public virtual override {
+      super.setUp();
+      // set time to contest completion
+      vm.warp(contestStart + voteDelay + votePeriod + 1);
+      instanceDefaultAdmin.pullElectionResults();
+      }
+      }
+      contract TestContestCompletedProposing2Scenario is ContestCompletedProposing2Scenario {
+      function test_eligibilityInstance() public {
+      (bool eligible1,) = instanceDefaultAdmin.getWearerStatus(candidate1, winnersHat);
+      assertEq(eligible1, true, "candidate 1 eligibility");
+      (bool eligible2,) = instanceDefaultAdmin.getWearerStatus(candidate2, winnersHat);
+      assertEq(eligible2, false, "candidate 2 eligibility");
+      (bool eligible3,) = instanceDefaultAdmin.getWearerStatus(candidate3, winnersHat);
+      assertEq(eligible3, false, "candidate 3 eligibility");
+      }
+      function test_eligibilityHats() public {
+      assertEq(HATS.isEligible(candidate1, winnersHat), true, "candidate 1 eligibility");
+      assertEq(HATS.isEligible(candidate2, winnersHat), false, "candidate 2 eligibility");
+      assertEq(HATS.isEligible(candidate3, winnersHat), false, "candidate 3 eligibility");
+      }
+      }
+      contract TestContestCompletedVoting2Proposing1Scenario is ContestCompletedVoting2Proposing1Scenario {
+      function test_pullResults_reverts() public {
+      vm.expectRevert(JokeraceEligibility_NoTies.selector);
+      instanceDefaultAdmin.pullElectionResults();
+      }
+      }
+      contract TestContestCompletedVoting1Proposing1Scenario is ContestCompletedVoting1Proposing1Scenario {
+      function test_eligibilityInstance() public {
+      (bool eligible1,) = instanceDefaultAdmin.getWearerStatus(candidate1, winnersHat);
+      assertEq(eligible1, true, "candidate 1 eligibility");
+      (bool eligible2,) = instanceDefaultAdmin.getWearerStatus(candidate2, winnersHat);
+      assertEq(eligible2, false, "candidate 2 eligibility");
+      (bool eligible3,) = instanceDefaultAdmin.getWearerStatus(candidate3, winnersHat);
+      assertEq(eligible3, true, "candidate 3 eligibility");
+      }
+      function test_eligibilityHats() public {
+      assertEq(HATS.isEligible(candidate1, winnersHat), true, "candidate 1 eligibility");
+      assertEq(HATS.isEligible(candidate2, winnersHat), false, "candidate 2 eligibility");
+      assertEq(HATS.isEligible(candidate3, winnersHat), true, "candidate 3 eligibility");
+      }
+      function test_setReelection_reverts() public {
+      vm.expectRevert(JokeraceEligibility_TermNotCompleted.selector);
+      instanceDefaultAdmin.reelection(address(contest), contestStart + voteDelay + votePeriod + termPeriod, 2);
+      }
+      }
+      // Current term ended, ready for reelection
+      contract TermEndedVoting1Proposing1Scenario is ContestCompletedVoting1Proposing1Scenario {
+      function setUp() public virtual override {
+      super.setUp();
+      // set time to contest completion
+      vm.warp(contestStart + voteDelay + votePeriod + termPeriod + 1);
+      }
+      }
+      contract TestTermEndedVoting1Proposing1Scenario is TermEndedVoting1Proposing1Scenario {
+      function test_setReelectionNotAdmin_reverts() public {
+      vm.startPrank(candidate1);
+      vm.expectRevert(JokeraceEligibility_NotAdmin.selector);
+      instanceDefaultAdmin.reelection(address(contest), contestStart + voteDelay + votePeriod + termPeriod, 2);
+      vm.stopPrank();
+      }
+      function test_eligibilityInstance() public {
+      (bool eligible1,) = instanceDefaultAdmin.getWearerStatus(candidate1, winnersHat);
+      assertEq(eligible1, false, "candidate 1 eligibility");
+      (bool eligible2,) = instanceDefaultAdmin.getWearerStatus(candidate2, winnersHat);
+      assertEq(eligible2, false, "candidate 2 eligibility");
+      (bool eligible3,) = instanceDefaultAdmin.getWearerStatus(candidate3, winnersHat);
+      assertEq(eligible3, false, "candidate 3 eligibility");
+      }
+      function test_eligibilityHats() public {
+      assertEq(HATS.isEligible(candidate1, winnersHat), false, "candidate 1 eligibility");
+      assertEq(HATS.isEligible(candidate2, winnersHat), false, "candidate 2 eligibility");
+      assertEq(HATS.isEligible(candidate3, winnersHat), false, "candidate 3 eligibility");
+      }
+      }
+      contract TestReelectionVoting1Proposing1Scenario is TermEndedVoting1Proposing1Scenario {
+      function setUp() public virtual override {
+      super.setUp();
+      // deploy a new contest
+      contestStart = block.timestamp;
+      args.push(contestStart);
+      args.push(voteDelay);
+      args.push(votePeriod);
+      args.push(contestStart);
+      args.push(0);
+      args.push(50);
+      args.push(50);
+      args.push(1);
+      args.push(1);
+      contest = new Contest("test contest reelection", "contest reelection", bytes32(0), votingMerkleRoot, args);
+      }
+      function test_reelection() public {
+      vm.prank(dao);
+      address newContest = makeAddr("newContest");
+      uint256 newTermEnd = block.timestamp + voteDelay + votePeriod;
+      uint256 newTopK = 5;
+      instanceDefaultAdmin.reelection(newContest, newTermEnd, newTopK);
+      assertEq(address(instanceDefaultAdmin.underlyingContest()), newContest);
+      assertEq(instanceDefaultAdmin.topK(), newTopK);
+      assertEq(instanceDefaultAdmin.termEnd(), newTermEnd);
+      }
+      }
+      contract TestReelectionHatAdmin is TestSetup {
+      function setUp() public virtual override {
+      super.setUp();
+      // set time to contest completion
+      vm.warp(contestStart + voteDelay + votePeriod + termPeriod + 1);
+      }
+      function test_reelectionByTopHat_reverts() public {
+      vm.startPrank(dao);
+      vm.expectRevert(JokeraceEligibility_NotAdmin.selector);
+      instanceHatAdmin.reelection(address(contest), contestStart + voteDelay + votePeriod + termPeriod, 2);
+      vm.stopPrank();
+      }
+      function test_reelectionDefaultAdmin() public {
+      vm.prank(optionalAdmin);
+      instanceHatAdmin.reelection(address(contest), contestStart + voteDelay + votePeriod + termPeriod, 2);
+      }
+      */
 }

--- a/test/JokeraceEligibility.t.sol
+++ b/test/JokeraceEligibility.t.sol
@@ -10,9 +10,9 @@ import {
   deployModuleFactory,
   deployModuleInstance
 } from "lib/hats-module/src/utils/DeployFunctions.sol";
-//import { GovernorSorting } from "jokerace/governance/extensions/GovernorSorting.sol";
+import { GovernorCountingSimple } from "jokerace/governance/extensions/GovernorCountingSimple.sol";
 import { Contest } from "jokerace/Contest.sol";
-//import { IGovernor } from "jokerace/governance/IGovernor.sol";
+import { Governor } from "jokerace/governance/Governor.sol";
 
 contract DeployImplementationTest is DeployImplementation, Test {
   // variables inherited from DeployImplementation script
@@ -20,414 +20,464 @@ contract DeployImplementationTest is DeployImplementation, Test {
   // bytes32 public SALT;
 
   uint256 public fork;
-  uint256 public BLOCK_NUMBER = 9_395_052; // the block number where hats module factory was deployed on Goerli;
-    /*
-      IHats public constant HATS = IHats(0x3bc1A0Ad72417f2d411118085256fC53CBdDd137); // v1.hatsprotocol.eth
-      string public FACTORY_VERSION = "factory test version";
-      string public JOKERACE_ELIGIBILITY_VERSION = "test version";
-      function setUp() public virtual {
-      // create and activate a fork, at BLOCK_NUMBER
-      fork = vm.createSelectFork(vm.rpcUrl("goerli"), BLOCK_NUMBER);
-      // deploy via the script
-      DeployImplementation.prepare(JOKERACE_ELIGIBILITY_VERSION, false); // set last arg to true to log deployment
-      DeployImplementation.run();
-      }
-      }
-      contract TestSetup is DeployImplementationTest {
-      error JokeraceEligibility_ContestNotCompleted();
-      error JokeraceEligibility_TermNotCompleted();
-      error JokeraceEligibility_NoTies();
-      error JokeraceEligibility_NotAdmin();
-      HatsModuleFactory constant FACTORY = HatsModuleFactory(0x60f7bE2ffc5672934146713fAe20Df350F21d8E2);
-      JokeraceEligibility public instanceDefaultAdmin;
-      JokeraceEligibility public instanceHatAdmin;
-      bytes public otherImmutableArgs;
-      bytes public initData;
-      uint256 public tophat;
-      uint256 public winnersHat;
-      uint256 public optionalAdminHat;
-      address public eligibility = makeAddr("eligibility");
-      address public toggle = makeAddr("toggle");
-      address public dao = makeAddr("dao");
-      address public minter = makeAddr("minter");
-      address public optionalAdmin = makeAddr("optionalAdmin");
-      address public candidate1 = makeAddr("candidate1");
-      address public candidate2 = makeAddr("candidate2");
-      address public candidate3 = makeAddr("candidate3");
-      bytes32 leaf1;
-      bytes32 leaf2;
-      bytes32 leaf3;
-      bytes32[] proof1;
-      bytes32[] proof2;
-      bytes32[] proof3;
-      bytes32 votingMerkleRoot;
-      address[] signers1 = [candidate1];
-      address[] signers2 = [candidate2];
-      address[] signers3 = [candidate3];
-      Contest contest;
-      //GenericVotesTimestampToken token;
-      uint256[] args;
-      uint256 contestStart;
-      uint256 constant voteDelay = 3600;
-      uint256 constant votePeriod = 3600;
-      uint256 constant termPeriod = 86_400;
-      enum ContestState {
-      NotStarted,
-      Active,
-      Canceled,
-      Queued,
-      Completed
-      }
-      function deployInstance(uint256 _winnersHat, uint256 _adminHat, address _contest, uint256 _termEnd, uint256 _topK)
-      public
-      returns (JokeraceEligibility)
-      {
-      // encode the other immutable args as packed bytes
-      otherImmutableArgs = abi.encodePacked(_adminHat);
-      // encoded the initData as unpacked bytes
-      initData = abi.encode(_contest, _termEnd, _topK);
-      // deploy the instance
-      return JokeraceEligibility(
+  uint256 public BLOCK_NUMBER = 9_713_194; // the block number where hats module factory was deployed on Goerli;
+
+  IHats public constant HATS = IHats(0x3bc1A0Ad72417f2d411118085256fC53CBdDd137); // v1.hatsprotocol.eth
+  string public FACTORY_VERSION = "factory test version";
+  string public JOKERACE_ELIGIBILITY_VERSION = "test version";
+
+  function setUp() public virtual {
+    // create and activate a fork, at BLOCK_NUMBER
+    fork = vm.createSelectFork(vm.rpcUrl("goerli"), BLOCK_NUMBER);
+    // deploy via the script
+    DeployImplementation.prepare(JOKERACE_ELIGIBILITY_VERSION, false); // set last arg to true to log deployment
+    DeployImplementation.run();
+  }
+}
+
+contract TestSetup is DeployImplementationTest {
+  error JokeraceEligibility_ContestNotCompleted();
+  error JokeraceEligibility_TermNotCompleted();
+  error JokeraceEligibility_NoTies();
+  error JokeraceEligibility_NotAdmin();
+
+  HatsModuleFactory constant FACTORY = HatsModuleFactory(0xfE661c01891172046feE16D3a57c3Cf456729efA);
+  JokeraceEligibility public instanceDefaultAdmin;
+  JokeraceEligibility public instanceHatAdmin;
+  bytes public otherImmutableArgs;
+  bytes public initData;
+  uint256 public tophat;
+  uint256 public winnersHat;
+  uint256 public optionalAdminHat;
+  address public eligibility = makeAddr("eligibility");
+  address public toggle = makeAddr("toggle");
+  address public dao = makeAddr("dao");
+  address public minter = makeAddr("minter");
+  address public optionalAdmin = makeAddr("optionalAdmin");
+  address public candidate1 = makeAddr("candidate1");
+  address public candidate2 = makeAddr("candidate2");
+  address public candidate3 = makeAddr("candidate3");
+  bytes32 leaf1;
+  bytes32 leaf2;
+  bytes32 leaf3;
+  bytes32[] proof1;
+  bytes32[] proof2;
+  bytes32[] proof3;
+  bytes32 votingMerkleRoot;
+  address[] signers1 = [candidate1];
+  address[] signers2 = [candidate2];
+  address[] signers3 = [candidate3];
+  Contest contest;
+  //GenericVotesTimestampToken token;
+  uint256[] args;
+  uint256 contestStart;
+  uint256 constant voteDelay = 3600;
+  uint256 constant votePeriod = 3600;
+  uint256 constant termPeriod = 86_400;
+
+  enum ContestState {
+    NotStarted,
+    Active,
+    Canceled,
+    Queued,
+    Completed
+  }
+
+  function deployInstance(uint256 _winnersHat, uint256 _adminHat, address _contest, uint256 _termEnd, uint256 _topK)
+    public
+    returns (JokeraceEligibility)
+  {
+    // encode the other immutable args as packed bytes
+    otherImmutableArgs = abi.encodePacked(_adminHat);
+    // encoded the initData as unpacked bytes
+    initData = abi.encode(_contest, _termEnd, _topK);
+    // deploy the instance
+    return JokeraceEligibility(
       deployModuleInstance(FACTORY, address(implementation), _winnersHat, otherImmutableArgs, initData)
-      );
-      }
-      function _efficientHash(bytes32 a, bytes32 b) private pure returns (bytes32 value) {
-      /// @solidity memory-safe-assembly
-      assembly {
+    );
+  }
+
+  function _efficientHash(bytes32 a, bytes32 b) private pure returns (bytes32 value) {
+    /// @solidity memory-safe-assembly
+    assembly {
       mstore(0x00, a)
       mstore(0x20, b)
       value := keccak256(0x00, 0x40)
-      }
-      }
-      function _hashPair(bytes32 a, bytes32 b) private pure returns (bytes32) {
-      return a < b ? _efficientHash(a, b) : _efficientHash(b, a);
-      }
-      function setUp() public virtual override {
-      super.setUp();
-      contestStart = block.timestamp;
-      // set up a contest
-      leaf1 = keccak256(abi.encodePacked(candidate1, uint256(100)));
-      leaf2 = keccak256(abi.encodePacked(candidate2, uint256(100)));
-      leaf3 = keccak256(abi.encodePacked(candidate3, uint256(100)));
-      proof1 = [leaf2, leaf3];
-      proof2 = [leaf1, leaf3];
-      proof3 = [_hashPair(leaf1, leaf2)];
-      votingMerkleRoot = _hashPair(_hashPair(leaf1, leaf2), leaf3);
-      args.push(contestStart);
-      args.push(voteDelay);
-      args.push(votePeriod);
-      args.push(50);
-      args.push(50);
-      args.push(1);
-      contest = new Contest("test contest", "contest", bytes32(0), votingMerkleRoot, args);
-      // set up hats
-      tophat = HATS.mintTopHat(dao, "tophat", "dao.eth/tophat");
-      vm.startPrank(dao);
-      winnersHat = HATS.createHat(tophat, "winnersHat", 50, eligibility, toggle, true, "dao.eth/winnersHat");
-      optionalAdminHat =
+    }
+  }
+
+  function _hashPair(bytes32 a, bytes32 b) private pure returns (bytes32) {
+    return a < b ? _efficientHash(a, b) : _efficientHash(b, a);
+  }
+
+  function setUp() public virtual override {
+    super.setUp();
+    contestStart = block.timestamp;
+    // set up a contest
+    leaf1 = keccak256(abi.encodePacked(candidate1, uint256(100)));
+    leaf2 = keccak256(abi.encodePacked(candidate2, uint256(100)));
+    leaf3 = keccak256(abi.encodePacked(candidate3, uint256(100)));
+    proof1 = [leaf2, leaf3];
+    proof2 = [leaf1, leaf3];
+    proof3 = [_hashPair(leaf1, leaf2)];
+    votingMerkleRoot = _hashPair(_hashPair(leaf1, leaf2), leaf3);
+    args.push(contestStart);
+    args.push(voteDelay);
+    args.push(votePeriod);
+    args.push(50);
+    args.push(50);
+    args.push(0);
+    args.push(0);
+    args.push(0);
+    args.push(1);
+    args.push(250);
+    contest = new Contest("test contest", "contest", bytes32(0), votingMerkleRoot, args);
+    // set up hats
+    tophat = HATS.mintTopHat(dao, "tophat", "dao.eth/tophat");
+    vm.startPrank(dao);
+    winnersHat = HATS.createHat(tophat, "winnersHat", 50, eligibility, toggle, true, "dao.eth/winnersHat");
+    optionalAdminHat =
       HATS.createHat(tophat, "optionalAdminHat", 50, eligibility, toggle, true, "dao.eth/optionalAdminHat");
-      HATS.mintHat(optionalAdminHat, optionalAdmin);
-      vm.stopPrank();
-      // deploy the eligibility instance with a default admin
-      instanceDefaultAdmin =
+    HATS.mintHat(optionalAdminHat, optionalAdmin);
+    vm.stopPrank();
+    // deploy the eligibility instance with a default admin
+    instanceDefaultAdmin =
       deployInstance(winnersHat, uint256(0), address(contest), contestStart + voteDelay + votePeriod + termPeriod, 2);
-      // deploy the eligibility instance with a specific hat admin. This instance is used only to check correct admin
-      // rights
-      instanceHatAdmin = deployInstance(
+    // deploy the eligibility instance with a specific hat admin. This instance is used only to check correct admin
+    // rights
+    instanceHatAdmin = deployInstance(
       winnersHat, optionalAdminHat, address(contest), contestStart + voteDelay + votePeriod + termPeriod, 2
-      );
-      // update winners hat eligibilty to instance
-      vm.prank(dao);
-      HATS.changeHatEligibility(winnersHat, address(instanceDefaultAdmin));
-      }
-      }
-      contract TestDeployment is TestSetup {
-      function test_deployImplementation() public {
-      assertEq(implementation.version_(), JOKERACE_ELIGIBILITY_VERSION, "implementation version");
-      }
-      function test_instanceDefaultAdmin() public {
-      assertEq(instanceDefaultAdmin.ADMIN_HAT(), uint256(0));
-      }
-      function test_instanceAdminHat() public {
-      assertEq(instanceHatAdmin.ADMIN_HAT(), optionalAdminHat);
-      }
-      function test_instanceContest() public {
-      assertEq(address(instanceDefaultAdmin.underlyingContest()), address(contest));
-      }
-      function test_instanceTermEnd() public {
-      assertEq(instanceDefaultAdmin.termEnd(), contest.contestDeadline() + 86_400);
-      }
-      function test_instanceTopK() public {
-      assertEq(instanceDefaultAdmin.topK(), 2);
-      }
-      function test_hatEligibility() public {
-      assertEq(
+    );
+    // update winners hat eligibilty to instance
+    vm.prank(dao);
+    HATS.changeHatEligibility(winnersHat, address(instanceDefaultAdmin));
+  }
+}
+
+contract TestDeployment is TestSetup {
+  function test_deployImplementation() public {
+    assertEq(implementation.version_(), JOKERACE_ELIGIBILITY_VERSION, "implementation version");
+  }
+
+  function test_instanceDefaultAdmin() public {
+    assertEq(instanceDefaultAdmin.ADMIN_HAT(), uint256(0));
+  }
+
+  function test_instanceAdminHat() public {
+    assertEq(instanceHatAdmin.ADMIN_HAT(), optionalAdminHat);
+  }
+
+  function test_instanceContest() public {
+    assertEq(address(instanceDefaultAdmin.underlyingContest()), address(contest));
+  }
+
+  function test_instanceTermEnd() public {
+    assertEq(instanceDefaultAdmin.termEnd(), contest.contestDeadline() + 86_400);
+  }
+
+  function test_instanceTopK() public {
+    assertEq(instanceDefaultAdmin.topK(), 2);
+  }
+
+  function test_hatEligibility() public {
+    assertEq(
       HATS.getHatEligibilityModule(winnersHat), address(instanceDefaultAdmin), "eligibility module of winners hat"
-      );
-      }
-      }
-      // Three candidates propose
-      contract Proposing1Scenario is TestSetup {
-      uint256[] proposalIds;
-      function setUp() public virtual override {
-      super.setUp();
-      // set time to  proposing period
-      vm.warp(contestStart + voteDelay - 1);
-      // each candidate proposes and delegates to itself
-      vm.prank(candidate1);
-      IGovernor.ProposalCore memory proposal1 = IGovernor.ProposalCore({
+    );
+  }
+}
+
+// Three candidates propose
+contract Proposing1Scenario is TestSetup {
+  uint256[] proposalIds;
+
+  function setUp() public virtual override {
+    super.setUp();
+    // set time to  proposing period
+    vm.warp(contestStart + voteDelay - 1);
+    // each candidate proposes and delegates to itself
+    vm.prank(candidate1);
+    Governor.ProposalCore memory proposal1 = Governor.ProposalCore({
       author: candidate1,
       description: "candidate 1 proposal",
       exists: true,
-      targetMetadata: IGovernor.TargetMetadata({ targetAddress: candidate1 }),
-      safeMetadata: IGovernor.SafeMetadata({ signers: signers1, threshold: 1 })
-      });
-      contest.proposeWithoutProof(proposal1);
-      vm.prank(candidate2);
-      IGovernor.ProposalCore memory proposal2 = IGovernor.ProposalCore({
+      targetMetadata: Governor.TargetMetadata({ targetAddress: candidate1 }),
+      safeMetadata: Governor.SafeMetadata({ signers: signers1, threshold: 1 })
+    });
+    contest.proposeWithoutProof(proposal1);
+    vm.prank(candidate2);
+    Governor.ProposalCore memory proposal2 = Governor.ProposalCore({
       author: candidate2,
       description: "candidate 2 proposal",
       exists: true,
-      targetMetadata: IGovernor.TargetMetadata({ targetAddress: candidate2 }),
-      safeMetadata: IGovernor.SafeMetadata({ signers: signers2, threshold: 1 })
-      });
-      contest.proposeWithoutProof(proposal2);
-      vm.prank(candidate3);
-      IGovernor.ProposalCore memory proposal3 = IGovernor.ProposalCore({
+      targetMetadata: Governor.TargetMetadata({ targetAddress: candidate2 }),
+      safeMetadata: Governor.SafeMetadata({ signers: signers2, threshold: 1 })
+    });
+    contest.proposeWithoutProof(proposal2);
+    vm.prank(candidate3);
+    Governor.ProposalCore memory proposal3 = Governor.ProposalCore({
       author: candidate3,
       description: "candidate 3 proposal",
       exists: true,
-      targetMetadata: IGovernor.TargetMetadata({ targetAddress: candidate3 }),
-      safeMetadata: IGovernor.SafeMetadata({ signers: signers3, threshold: 1 })
-      });
-      contest.proposeWithoutProof(proposal3);
-      proposalIds = contest.getAllProposalIds();
-      }
-      }
-      // Only one candidate proposes
-      contract Proposing2Scenario is TestSetup {
-      uint256[] proposalIds;
-      function setUp() public virtual override {
-      super.setUp();
-      // set time to  proposing period
-      vm.warp(contestStart + voteDelay - 1);
-      // only one proposal
-      vm.prank(candidate1);
-      IGovernor.ProposalCore memory proposal1 = IGovernor.ProposalCore({
+      targetMetadata: Governor.TargetMetadata({ targetAddress: candidate3 }),
+      safeMetadata: Governor.SafeMetadata({ signers: signers3, threshold: 1 })
+    });
+    contest.proposeWithoutProof(proposal3);
+    proposalIds = contest.getAllProposalIds();
+  }
+}
+
+// Only one candidate proposes
+contract Proposing2Scenario is TestSetup {
+  uint256[] proposalIds;
+
+  function setUp() public virtual override {
+    super.setUp();
+    // set time to  proposing period
+    vm.warp(contestStart + voteDelay - 1);
+    // only one proposal
+    vm.prank(candidate1);
+    Governor.ProposalCore memory proposal1 = Governor.ProposalCore({
       author: candidate1,
       description: "candidate 1 proposal",
       exists: true,
-      targetMetadata: IGovernor.TargetMetadata({ targetAddress: candidate1 }),
-      safeMetadata: IGovernor.SafeMetadata({ signers: signers1, threshold: 1 })
-      });
-      contest.proposeWithoutProof(proposal1);
-      proposalIds = contest.getAllProposalIds();
-      }
-      }
-      contract TestProposing1Scenario is Proposing1Scenario {
-      function setUp() public virtual override {
-      super.setUp();
-      }
-      function test_contestState() public {
-      assertEq(uint256(contest.state()), uint256(ContestState.Queued), "contest proposing state");
-      }
-      function test_proposals() public {
-      assertEq(proposalIds.length, 3, "number of proposals");
-      }
-      function test_pullContestResults_reverts() public {
-      vm.expectRevert(JokeraceEligibility_ContestNotCompleted.selector);
-      instanceDefaultAdmin.pullElectionResults();
-      }
-      function test_setReelection_reverts() public {
-      vm.expectRevert(JokeraceEligibility_TermNotCompleted.selector);
-      instanceDefaultAdmin.reelection(address(contest), contestStart + voteDelay + votePeriod + termPeriod, 2);
-      }
-      }
-      // Candidates scoring: candidate 1 > candidate 2 > candidate 3
-      contract Voting1Proposing1Scenario is Proposing1Scenario {
-      function setUp() public virtual override {
-      super.setUp();
-      // set time to voting period
-      vm.warp(contestStart + voteDelay + 1);
-      // candidates vote
-      vm.prank(candidate1);
-      contest.castVote(proposalIds[0], 0, 100, 100, proof1);
-      vm.prank(candidate2);
-      contest.castVote(proposalIds[1], 0, 100, 50, proof2);
-      vm.prank(candidate3);
-      contest.castVote(proposalIds[2], 0, 100, 100, proof3);
-      }
-      }
-      // Candidates scoring (tie between second and third place): candidate 1 > candidate 2 = candidate 3
-      contract Voting2Proposing1Scenario is Proposing1Scenario {
-      function setUp() public virtual override {
-      super.setUp();
-      // set time to voting period
-      vm.warp(contestStart + voteDelay + 1);
-      // candidates vote
-      vm.prank(candidate1);
-      contest.castVote(proposalIds[0], 0, 100, 100, proof1);
-      vm.prank(candidate2);
-      contest.castVote(proposalIds[1], 0, 100, 100, proof2);
-      vm.prank(candidate3);
-      contest.castVote(proposalIds[2], 0, 100, 100, proof3);
-      }
-      }
-      contract TestVoting1Proposing1Scenario is Voting1Proposing1Scenario {
-      function test_candidateVotes() public {
-      (uint256 forVotes1, uint256 againstVotes1) = contest.proposalVotes(proposalIds[0]);
-      assertEq(int256(forVotes1) - int256(againstVotes1), 100, "candidate 1 votes");
-      (uint256 forVotes2, uint256 againstVotes2) = contest.proposalVotes(proposalIds[1]);
-      assertEq(int256(forVotes2) - int256(againstVotes2), 50, "candidate 2 votes");
-      (uint256 forVotes3, uint256 againstVotes3) = contest.proposalVotes(proposalIds[2]);
-      assertEq(int256(forVotes3) - int256(againstVotes3), 100, "candidate 3 votes");
-      }
-      function test_pullContestResults_reverts() public {
-      vm.expectRevert(JokeraceEligibility_ContestNotCompleted.selector);
-      instanceDefaultAdmin.pullElectionResults();
-      }
-      function test_setReelection_reverts() public {
-      vm.expectRevert(JokeraceEligibility_TermNotCompleted.selector);
-      instanceDefaultAdmin.reelection(address(contest), contestStart + voteDelay + votePeriod + termPeriod, 2);
-      }
-      }
-      // Contest completed with candidates 1 & 2 as winners
-      contract ContestCompletedVoting1Proposing1Scenario is Voting1Proposing1Scenario {
-      function setUp() public virtual override {
-      super.setUp();
-      // set time to contest completion
-      vm.warp(contestStart + voteDelay + votePeriod + 1);
-      instanceDefaultAdmin.pullElectionResults();
-      }
-      }
-      // Contest completed with a tie (should not accept ties)
-      contract ContestCompletedVoting2Proposing1Scenario is Voting2Proposing1Scenario {
-      function setUp() public virtual override {
-      super.setUp();
-      // set time to contest completion
-      vm.warp(contestStart + voteDelay + votePeriod + 1);
-      }
-      }
-      // Contest completed with only one candidate, which is less than topK (2)
-      contract ContestCompletedProposing2Scenario is Proposing2Scenario {
-      function setUp() public virtual override {
-      super.setUp();
-      // set time to contest completion
-      vm.warp(contestStart + voteDelay + votePeriod + 1);
-      instanceDefaultAdmin.pullElectionResults();
-      }
-      }
-      contract TestContestCompletedProposing2Scenario is ContestCompletedProposing2Scenario {
-      function test_eligibilityInstance() public {
-      (bool eligible1,) = instanceDefaultAdmin.getWearerStatus(candidate1, winnersHat);
-      assertEq(eligible1, true, "candidate 1 eligibility");
-      (bool eligible2,) = instanceDefaultAdmin.getWearerStatus(candidate2, winnersHat);
-      assertEq(eligible2, false, "candidate 2 eligibility");
-      (bool eligible3,) = instanceDefaultAdmin.getWearerStatus(candidate3, winnersHat);
-      assertEq(eligible3, false, "candidate 3 eligibility");
-      }
-      function test_eligibilityHats() public {
-      assertEq(HATS.isEligible(candidate1, winnersHat), true, "candidate 1 eligibility");
-      assertEq(HATS.isEligible(candidate2, winnersHat), false, "candidate 2 eligibility");
-      assertEq(HATS.isEligible(candidate3, winnersHat), false, "candidate 3 eligibility");
-      }
-      }
-      contract TestContestCompletedVoting2Proposing1Scenario is ContestCompletedVoting2Proposing1Scenario {
-      function test_pullResults_reverts() public {
-      vm.expectRevert(JokeraceEligibility_NoTies.selector);
-      instanceDefaultAdmin.pullElectionResults();
-      }
-      }
-      contract TestContestCompletedVoting1Proposing1Scenario is ContestCompletedVoting1Proposing1Scenario {
-      function test_eligibilityInstance() public {
-      (bool eligible1,) = instanceDefaultAdmin.getWearerStatus(candidate1, winnersHat);
-      assertEq(eligible1, true, "candidate 1 eligibility");
-      (bool eligible2,) = instanceDefaultAdmin.getWearerStatus(candidate2, winnersHat);
-      assertEq(eligible2, false, "candidate 2 eligibility");
-      (bool eligible3,) = instanceDefaultAdmin.getWearerStatus(candidate3, winnersHat);
-      assertEq(eligible3, true, "candidate 3 eligibility");
-      }
-      function test_eligibilityHats() public {
-      assertEq(HATS.isEligible(candidate1, winnersHat), true, "candidate 1 eligibility");
-      assertEq(HATS.isEligible(candidate2, winnersHat), false, "candidate 2 eligibility");
-      assertEq(HATS.isEligible(candidate3, winnersHat), true, "candidate 3 eligibility");
-      }
-      function test_setReelection_reverts() public {
-      vm.expectRevert(JokeraceEligibility_TermNotCompleted.selector);
-      instanceDefaultAdmin.reelection(address(contest), contestStart + voteDelay + votePeriod + termPeriod, 2);
-      }
-      }
-      // Current term ended, ready for reelection
-      contract TermEndedVoting1Proposing1Scenario is ContestCompletedVoting1Proposing1Scenario {
-      function setUp() public virtual override {
-      super.setUp();
-      // set time to contest completion
-      vm.warp(contestStart + voteDelay + votePeriod + termPeriod + 1);
-      }
-      }
-      contract TestTermEndedVoting1Proposing1Scenario is TermEndedVoting1Proposing1Scenario {
-      function test_setReelectionNotAdmin_reverts() public {
-      vm.startPrank(candidate1);
-      vm.expectRevert(JokeraceEligibility_NotAdmin.selector);
-      instanceDefaultAdmin.reelection(address(contest), contestStart + voteDelay + votePeriod + termPeriod, 2);
-      vm.stopPrank();
-      }
-      function test_eligibilityInstance() public {
-      (bool eligible1,) = instanceDefaultAdmin.getWearerStatus(candidate1, winnersHat);
-      assertEq(eligible1, false, "candidate 1 eligibility");
-      (bool eligible2,) = instanceDefaultAdmin.getWearerStatus(candidate2, winnersHat);
-      assertEq(eligible2, false, "candidate 2 eligibility");
-      (bool eligible3,) = instanceDefaultAdmin.getWearerStatus(candidate3, winnersHat);
-      assertEq(eligible3, false, "candidate 3 eligibility");
-      }
-      function test_eligibilityHats() public {
-      assertEq(HATS.isEligible(candidate1, winnersHat), false, "candidate 1 eligibility");
-      assertEq(HATS.isEligible(candidate2, winnersHat), false, "candidate 2 eligibility");
-      assertEq(HATS.isEligible(candidate3, winnersHat), false, "candidate 3 eligibility");
-      }
-      }
-      contract TestReelectionVoting1Proposing1Scenario is TermEndedVoting1Proposing1Scenario {
-      function setUp() public virtual override {
-      super.setUp();
-      // deploy a new contest
-      contestStart = block.timestamp;
-      args.push(contestStart);
-      args.push(voteDelay);
-      args.push(votePeriod);
-      args.push(contestStart);
-      args.push(0);
-      args.push(50);
-      args.push(50);
-      args.push(1);
-      args.push(1);
-      contest = new Contest("test contest reelection", "contest reelection", bytes32(0), votingMerkleRoot, args);
-      }
-      function test_reelection() public {
-      vm.prank(dao);
-      address newContest = makeAddr("newContest");
-      uint256 newTermEnd = block.timestamp + voteDelay + votePeriod;
-      uint256 newTopK = 5;
-      instanceDefaultAdmin.reelection(newContest, newTermEnd, newTopK);
-      assertEq(address(instanceDefaultAdmin.underlyingContest()), newContest);
-      assertEq(instanceDefaultAdmin.topK(), newTopK);
-      assertEq(instanceDefaultAdmin.termEnd(), newTermEnd);
-      }
-      }
-      contract TestReelectionHatAdmin is TestSetup {
-      function setUp() public virtual override {
-      super.setUp();
-      // set time to contest completion
-      vm.warp(contestStart + voteDelay + votePeriod + termPeriod + 1);
-      }
-      function test_reelectionByTopHat_reverts() public {
-      vm.startPrank(dao);
-      vm.expectRevert(JokeraceEligibility_NotAdmin.selector);
-      instanceHatAdmin.reelection(address(contest), contestStart + voteDelay + votePeriod + termPeriod, 2);
-      vm.stopPrank();
-      }
-      function test_reelectionDefaultAdmin() public {
-      vm.prank(optionalAdmin);
-      instanceHatAdmin.reelection(address(contest), contestStart + voteDelay + votePeriod + termPeriod, 2);
-      }
-      */
+      targetMetadata: Governor.TargetMetadata({ targetAddress: candidate1 }),
+      safeMetadata: Governor.SafeMetadata({ signers: signers1, threshold: 1 })
+    });
+    contest.proposeWithoutProof(proposal1);
+    proposalIds = contest.getAllProposalIds();
+  }
+}
+
+contract TestProposing1Scenario is Proposing1Scenario {
+  function setUp() public virtual override {
+    super.setUp();
+  }
+
+  function test_contestState() public {
+    assertEq(uint256(contest.state()), uint256(ContestState.Queued), "contest proposing state");
+  }
+
+  function test_proposals() public {
+    assertEq(proposalIds.length, 3, "number of proposals");
+  }
+
+  function test_pullContestResults_reverts() public {
+    vm.expectRevert(JokeraceEligibility_ContestNotCompleted.selector);
+    instanceDefaultAdmin.pullElectionResults();
+  }
+
+  function test_setReelection_reverts() public {
+    vm.expectRevert(JokeraceEligibility_TermNotCompleted.selector);
+    instanceDefaultAdmin.reelection(address(contest), contestStart + voteDelay + votePeriod + termPeriod, 2);
+  }
+}
+// Candidates scoring: candidate 1 > candidate 2 > candidate 3
+
+contract Voting1Proposing1Scenario is Proposing1Scenario {
+  function setUp() public virtual override {
+    super.setUp();
+    // set time to voting period
+    vm.warp(contestStart + voteDelay + 1);
+    // candidates vote
+    vm.prank(candidate1);
+    contest.castVote(proposalIds[0], 0, 100, 100, proof1);
+    vm.prank(candidate2);
+    contest.castVote(proposalIds[1], 0, 100, 50, proof2);
+    vm.prank(candidate3);
+    contest.castVote(proposalIds[2], 0, 100, 100, proof3);
+  }
+}
+// Candidates scoring (tie between second and third place): candidate 1 > candidate 2 = candidate 3
+
+contract Voting2Proposing1Scenario is Proposing1Scenario {
+  function setUp() public virtual override {
+    super.setUp();
+    // set time to voting period
+    vm.warp(contestStart + voteDelay + 1);
+    // candidates vote
+    vm.prank(candidate1);
+    contest.castVote(proposalIds[0], 0, 100, 100, proof1);
+    vm.prank(candidate2);
+    contest.castVote(proposalIds[1], 0, 100, 100, proof2);
+    vm.prank(candidate3);
+    contest.castVote(proposalIds[2], 0, 100, 100, proof3);
+  }
+}
+
+contract TestVoting1Proposing1Scenario is Voting1Proposing1Scenario {
+  function test_candidateVotes() public {
+    (uint256 forVotes1, uint256 againstVotes1) = contest.proposalVotes(proposalIds[0]);
+    assertEq(int256(forVotes1) - int256(againstVotes1), 100, "candidate 1 votes");
+    (uint256 forVotes2, uint256 againstVotes2) = contest.proposalVotes(proposalIds[1]);
+    assertEq(int256(forVotes2) - int256(againstVotes2), 50, "candidate 2 votes");
+    (uint256 forVotes3, uint256 againstVotes3) = contest.proposalVotes(proposalIds[2]);
+    assertEq(int256(forVotes3) - int256(againstVotes3), 100, "candidate 3 votes");
+  }
+
+  function test_pullContestResults_reverts() public {
+    vm.expectRevert(JokeraceEligibility_ContestNotCompleted.selector);
+    instanceDefaultAdmin.pullElectionResults();
+  }
+
+  function test_setReelection_reverts() public {
+    vm.expectRevert(JokeraceEligibility_TermNotCompleted.selector);
+    instanceDefaultAdmin.reelection(address(contest), contestStart + voteDelay + votePeriod + termPeriod, 2);
+  }
+}
+// Contest completed with candidates 1 & 2 as winners
+
+contract ContestCompletedVoting1Proposing1Scenario is Voting1Proposing1Scenario {
+  function setUp() public virtual override {
+    super.setUp();
+    // set time to contest completion
+    vm.warp(contestStart + voteDelay + votePeriod + 1);
+    instanceDefaultAdmin.pullElectionResults();
+  }
+}
+// Contest completed with a tie (should not accept ties)
+
+contract ContestCompletedVoting2Proposing1Scenario is Voting2Proposing1Scenario {
+  function setUp() public virtual override {
+    super.setUp();
+    // set time to contest completion
+    vm.warp(contestStart + voteDelay + votePeriod + 1);
+  }
+}
+// Contest completed with only one candidate, which is less than topK (2)
+
+contract ContestCompletedProposing2Scenario is Proposing2Scenario {
+  function setUp() public virtual override {
+    super.setUp();
+    // set time to contest completion
+    vm.warp(contestStart + voteDelay + votePeriod + 1);
+    instanceDefaultAdmin.pullElectionResults();
+  }
+}
+
+contract TestContestCompletedProposing2Scenario is ContestCompletedProposing2Scenario {
+  function test_eligibilityInstance() public {
+    (bool eligible1,) = instanceDefaultAdmin.getWearerStatus(candidate1, winnersHat);
+    assertEq(eligible1, false, "candidate 1 eligibility");
+    (bool eligible2,) = instanceDefaultAdmin.getWearerStatus(candidate2, winnersHat);
+    assertEq(eligible2, false, "candidate 2 eligibility");
+    (bool eligible3,) = instanceDefaultAdmin.getWearerStatus(candidate3, winnersHat);
+    assertEq(eligible3, false, "candidate 3 eligibility");
+  }
+
+  function test_eligibilityHats() public {
+    assertEq(HATS.isEligible(candidate1, winnersHat), false, "candidate 1 eligibility");
+    assertEq(HATS.isEligible(candidate2, winnersHat), false, "candidate 2 eligibility");
+    assertEq(HATS.isEligible(candidate3, winnersHat), false, "candidate 3 eligibility");
+  }
+}
+
+contract TestContestCompletedVoting2Proposing1Scenario is ContestCompletedVoting2Proposing1Scenario {
+  function test_pullResults_reverts() public {
+    vm.expectRevert(JokeraceEligibility_NoTies.selector);
+    instanceDefaultAdmin.pullElectionResults();
+  }
+}
+
+contract TestContestCompletedVoting1Proposing1Scenario is ContestCompletedVoting1Proposing1Scenario {
+  function test_eligibilityInstance() public {
+    (bool eligible1,) = instanceDefaultAdmin.getWearerStatus(candidate1, winnersHat);
+    assertEq(eligible1, true, "candidate 1 eligibility");
+    (bool eligible2,) = instanceDefaultAdmin.getWearerStatus(candidate2, winnersHat);
+    assertEq(eligible2, false, "candidate 2 eligibility");
+    (bool eligible3,) = instanceDefaultAdmin.getWearerStatus(candidate3, winnersHat);
+    assertEq(eligible3, true, "candidate 3 eligibility");
+  }
+
+  function test_eligibilityHats() public {
+    assertEq(HATS.isEligible(candidate1, winnersHat), true, "candidate 1 eligibility");
+    assertEq(HATS.isEligible(candidate2, winnersHat), false, "candidate 2 eligibility");
+    assertEq(HATS.isEligible(candidate3, winnersHat), true, "candidate 3 eligibility");
+  }
+
+  function test_setReelection_reverts() public {
+    vm.expectRevert(JokeraceEligibility_TermNotCompleted.selector);
+    instanceDefaultAdmin.reelection(address(contest), contestStart + voteDelay + votePeriod + termPeriod, 2);
+  }
+}
+// Current term ended, ready for reelection
+
+contract TermEndedVoting1Proposing1Scenario is ContestCompletedVoting1Proposing1Scenario {
+  function setUp() public virtual override {
+    super.setUp();
+    // set time to contest completion
+    vm.warp(contestStart + voteDelay + votePeriod + termPeriod + 1);
+  }
+}
+
+contract TestTermEndedVoting1Proposing1Scenario is TermEndedVoting1Proposing1Scenario {
+  function test_setReelectionNotAdmin_reverts() public {
+    vm.startPrank(candidate1);
+    vm.expectRevert(JokeraceEligibility_NotAdmin.selector);
+    instanceDefaultAdmin.reelection(address(contest), contestStart + voteDelay + votePeriod + termPeriod, 2);
+    vm.stopPrank();
+  }
+
+  function test_eligibilityInstance() public {
+    (bool eligible1,) = instanceDefaultAdmin.getWearerStatus(candidate1, winnersHat);
+    assertEq(eligible1, false, "candidate 1 eligibility");
+    (bool eligible2,) = instanceDefaultAdmin.getWearerStatus(candidate2, winnersHat);
+    assertEq(eligible2, false, "candidate 2 eligibility");
+    (bool eligible3,) = instanceDefaultAdmin.getWearerStatus(candidate3, winnersHat);
+    assertEq(eligible3, false, "candidate 3 eligibility");
+  }
+
+  function test_eligibilityHats() public {
+    assertEq(HATS.isEligible(candidate1, winnersHat), false, "candidate 1 eligibility");
+    assertEq(HATS.isEligible(candidate2, winnersHat), false, "candidate 2 eligibility");
+    assertEq(HATS.isEligible(candidate3, winnersHat), false, "candidate 3 eligibility");
+  }
+}
+
+contract TestReelectionVoting1Proposing1Scenario is TermEndedVoting1Proposing1Scenario {
+  function setUp() public virtual override {
+    super.setUp();
+    // deploy a new contest
+    contestStart = block.timestamp;
+    args.push(contestStart);
+    args.push(voteDelay);
+    args.push(votePeriod);
+    args.push(contestStart);
+    args.push(0);
+    args.push(50);
+    args.push(50);
+    args.push(1);
+    args.push(1);
+    contest = new Contest("test contest reelection", "contest reelection", bytes32(0), votingMerkleRoot, args);
+  }
+
+  function test_reelection() public {
+    vm.prank(dao);
+    address newContest = makeAddr("newContest");
+    uint256 newTermEnd = block.timestamp + voteDelay + votePeriod;
+    uint256 newTopK = 5;
+    instanceDefaultAdmin.reelection(newContest, newTermEnd, newTopK);
+    assertEq(address(instanceDefaultAdmin.underlyingContest()), newContest);
+    assertEq(instanceDefaultAdmin.topK(), newTopK);
+    assertEq(instanceDefaultAdmin.termEnd(), newTermEnd);
+  }
+}
+
+contract TestReelectionHatAdmin is TestSetup {
+  function setUp() public virtual override {
+    super.setUp();
+    // set time to contest completion
+    vm.warp(contestStart + voteDelay + votePeriod + termPeriod + 1);
+  }
+
+  function test_reelectionByTopHat_reverts() public {
+    vm.startPrank(dao);
+    vm.expectRevert(JokeraceEligibility_NotAdmin.selector);
+    instanceHatAdmin.reelection(address(contest), contestStart + voteDelay + votePeriod + termPeriod, 2);
+    vm.stopPrank();
+  }
+
+  function test_reelectionDefaultAdmin() public {
+    vm.prank(optionalAdmin);
+    instanceHatAdmin.reelection(address(contest), contestStart + voteDelay + votePeriod + termPeriod, 2);
+  }
 }

--- a/test/JokeraceEligibility.t.sol
+++ b/test/JokeraceEligibility.t.sol
@@ -165,13 +165,6 @@ contract TestSetup is DeployImplementationTest {
       winnersHat, optionalAdminHat, address(contest), contestStart + voteDelay + votePeriod + termPeriod, 2
     );
 
-    instanceWithDownVoting = deployInstance(
-      winnersHat, uint256(1), address(contestWithDownVoting), contestStart + voteDelay + votePeriod + termPeriod, 2
-    );
-    instancewithSortingDisabled = deployInstance(
-      winnersHat, uint256(2), address(contestWithSortingDisabled), contestStart + voteDelay + votePeriod + termPeriod, 2
-    );
-
     // update winners hat eligibilty to instance
     vm.prank(dao);
     HATS.changeHatEligibility(winnersHat, address(instanceDefaultAdmin));
@@ -458,25 +451,30 @@ contract TestTermEndedVoting1Proposing1Scenario is TermEndedVoting1Proposing1Sce
 }
 
 contract TestReelectionVoting1Proposing1Scenario is TermEndedVoting1Proposing1Scenario {
+  address public newContest;
+
   function setUp() public virtual override {
     super.setUp();
     // deploy a new contest
     contestStart = block.timestamp;
-    args.push(contestStart);
-    args.push(voteDelay);
-    args.push(votePeriod);
-    args.push(contestStart);
-    args.push(0);
-    args.push(50);
-    args.push(50);
-    args.push(1);
-    args.push(1);
-    contest = new Contest("test contest reelection", "contest reelection", bytes32(0), votingMerkleRoot, args);
+    uint256[] memory newContestArgs = new uint256[](10);
+    newContestArgs[0] = contestStart;
+    newContestArgs[1] = voteDelay;
+    newContestArgs[2] = votePeriod;
+    newContestArgs[3] = 50;
+    newContestArgs[4] = 50;
+    newContestArgs[5] = 0;
+    newContestArgs[6] = 0;
+    newContestArgs[7] = 0;
+    newContestArgs[8] = 1;
+    newContestArgs[9] = 250;
+    newContest = address(
+      new Contest("test contest reelection", "contest reelection", bytes32(0), votingMerkleRoot, newContestArgs)
+    );
   }
 
   function test_reelection() public {
     vm.prank(dao);
-    address newContest = makeAddr("newContest");
     uint256 newTermEnd = block.timestamp + voteDelay + votePeriod;
     uint256 newTopK = 5;
     instanceDefaultAdmin.reelection(newContest, newTermEnd, newTopK);
@@ -515,7 +513,9 @@ contract TestContestWithDownVoting is TestSetup {
 
   function test_pullElectionResults_reverts() public {
     vm.expectRevert(JokeraceEligibility_MustHaveDownvotingDisabled.selector);
-    instanceWithDownVoting.pullElectionResults();
+    deployInstance(
+      winnersHat, uint256(1), address(contestWithDownVoting), contestStart + voteDelay + votePeriod + termPeriod, 2
+    );
   }
 }
 
@@ -528,6 +528,8 @@ contract TestContestWithSortingDisabled is TestSetup {
 
   function test_pullElectionResults_reverts() public {
     vm.expectRevert(JokeraceEligibility_MustHaveSortingEnabled.selector);
-    instancewithSortingDisabled.pullElectionResults();
+    deployInstance(
+      winnersHat, uint256(1), address(contestWithSortingDisabled), contestStart + voteDelay + votePeriod + termPeriod, 2
+    );
   }
 }


### PR DESCRIPTION
Updating the module, following Jokerace's updated sorting mechanism. With this new mechanism, the proposals sorting is maintained through out the contest, adjusted after each operation (new proposals, voting...). With the previous implementation, the proposals sorting happened at the end of the contest, when asked via the `pullElectionResults` function. 
Few points of consideration:
- Jokerace's sorting mechanism is enabled only for contests without down-voting and with enabled sorting (two separate flags that are defined at the contest's creation). And so the current module implementation will work only for this kind of contests. 
- Proposals with a zero score are not "ranked", meaning that they cannot become part of the reward receivers.
- The new module implementation checks that the contest is without down-voting and that sorting is enabled. It does so at module creation and reelection. If not, it reverts
- If there's a tie, the module will update the `termEnd` to the current timestamp in order to enable reelection. This happens at the `pullElectionResults` function